### PR TITLE
(bugfix) Create mappings for DTO classes.

### DIFF
--- a/Pfps.API/ClassMap.cs
+++ b/Pfps.API/ClassMap.cs
@@ -10,6 +10,9 @@ namespace Pfps.API
         {
             // Use for more advanced class maps later on.
 
+            CreateMap<Upload, UploadViewModel>();
+            CreateMap<Notification, NotificationViewModel>();
+
             CreateMap<User, UserViewModel>()
                 .ForMember(d => d.DiscordId,
                 f => f.MapFrom(x => x.HasLinkedDiscord ? x.Password : null)); // this might crash


### PR DESCRIPTION
Missing mappings for `AutoMapper` caused 5xx errors to be thrown due to ClassMaps not being defined for DTOs.